### PR TITLE
docs: add getty-msgpack to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,5 @@ exe.root_module.addImport("msgpack", msgpack.module("msgpack"));
 
 ## Related projects
 
+- [getty-msgpack](https://git.mzte.de/LordMZTE/getty-msgpack)
 - [znvim](https://github.com/jinzhongjia/znvim)


### PR DESCRIPTION
This adds my project, getty-msgpack to the list of related projects. It is an implementation of msgpack in Zig for the Getty serialization framework (similar to Rust's serde).