### PR TITLE
fix: write array len after array16 && array32 header definitions

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .zig_msgpack,
     .version = "0.0.7",
-    .fingerprint = 0x14a3e10e78eefb7a,
+    .fingerprint = 0x14a3e10e303fa395,
     .minimum_zig_version = "0.14.0",
     .dependencies = .{},
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .zig_msgpack,
     .version = "0.0.7",
-    .fingerprint = 0x14a3e10e303fa395,
+    .fingerprint = 0x14a3e10e78eefb7a,
     .minimum_zig_version = "0.14.0",
     .dependencies = .{},
     .paths = .{

--- a/src/msgpack.zig
+++ b/src/msgpack.zig
@@ -837,8 +837,10 @@ pub fn Pack(
                         try self.writeU8Value(header);
                     } else if (len <= 0xffff) {
                         try self.writeTypeMarker(.ARRAY16);
+                        try self.writeU16Value(@as(u16, @intCast(len)));
                     } else if (len <= 0xffff_ffff) {
                         try self.writeTypeMarker(.ARRAY32);
+                        try self.writeU32Value(@as(u32, @intCast(len)));
                     } else {
                         return MsGPackError.MAP_LENGTH_TOO_LONG;
                     }


### PR DESCRIPTION
Arary16 and Array32 writes didn't include the length after their header writes, so I've added them and a generic test for 16 elements which should trigger the 0xdc write and force an array16.

I've checked it against msgpack-tools, itself and a go implementation I was sending between and it works.

Lemme know if you want any changes, love your work <3