### PR TITLE
feat: add unit test and  timestamp support 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
               with:
                   fetch-depth: 0
             - name: Build and test with Zig
-              run: zig build test
+              run: zig build test --summary all

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ An article introducing it: [Zig Msgpack](https://blog.nvimer.org/2025/05/03/zig-
 
 ## Features
 
-- **Full MessagePack Support:** Implements all MessagePack types (except for the timestamp extension).
+- **Full MessagePack Support:** Implements all MessagePack types including the timestamp extension.
+- **Timestamp Support:** Complete implementation of MessagePack timestamp extension type (-1) with support for all three formats (32-bit, 64-bit, and 96-bit).
 - **Efficient:** Designed for high performance with minimal memory overhead.
 - **Type-Safe:** Leverages Zig's type system to ensure safety during serialization and deserialization.
 - **Simple API:** Offers a straightforward and easy-to-use API for encoding and decoding.
@@ -56,56 +57,100 @@ For Zig `0.14.0` and `nightly`, follow these steps:
 
 ## Usage
 
-Here is a simple example of how to encode and decode a `Payload`:
+### Basic Usage
 
 ```zig
 const std = @import("std");
 const msgpack = @import("msgpack");
-const allocator = std.testing.allocator;
 
 pub fn main() !void {
+    const allocator = std.heap.page_allocator;
     var buffer: [1024]u8 = undefined;
     var stream = std.io.fixedBufferStream(&buffer);
 
     var packer = msgpack.Pack(
-        *std.io.FixedBufferStream([]u8),
-        *std.io.FixedBufferStream([]u8),
-        std.io.FixedBufferStream([]u8).WriteError,
-        std.io.FixedBufferStream([]u8).ReadError,
-        std.io.FixedBufferStream([]u8).write,
-        std.io.FixedBufferStream([]u8).read,
+        *std.io.FixedBufferStream([]u8), *std.io.FixedBufferStream([]u8),
+        std.io.FixedBufferStream([]u8).WriteError, std.io.FixedBufferStream([]u8).ReadError,
+        std.io.FixedBufferStream([]u8).write, std.io.FixedBufferStream([]u8).read,
     ).init(&stream, &stream);
 
-    // Create a map payload
+    // Create and encode data
     var map = msgpack.Payload.mapPayload(allocator);
     defer map.free(allocator);
-
-    try map.mapPut("message", try msgpack.Payload.strToPayload("Hello, MessagePack!", allocator));
-    try map.mapPut("version", msgpack.Payload.uintToPayload(1));
-
-    // Encode
+    try map.mapPut("name", try msgpack.Payload.strToPayload("Alice", allocator));
+    try map.mapPut("age", msgpack.Payload.uintToPayload(30));
     try packer.write(map);
 
-    // Reset stream for reading
-    stream.pos = 0;
-
     // Decode
-    const decoded_payload = try packer.read(allocator);
-    defer decoded_payload.free(allocator);
-
-    // Use the decoded data
-    const message = (try decoded_payload.mapGet("message")).?.str.value();
-    const version = (try decoded_payload.mapGet("version")).?.uint;
-
-    std.debug.print("Message: {s}, Version: {d}
-", .{ message, version });
+    stream.pos = 0;
+    const decoded = try packer.read(allocator);
+    defer decoded.free(allocator);
+    
+    const name = (try decoded.mapGet("name")).?.str.value();
+    const age = (try decoded.mapGet("age")).?.uint;
+    std.debug.print("Name: {s}, Age: {d}\n", .{ name, age });
 }
+```
+
+### Data Types
+
+```zig
+// Basic types
+const nil_val = msgpack.Payload.nilToPayload();
+const bool_val = msgpack.Payload.boolToPayload(true);
+const int_val = msgpack.Payload.intToPayload(-42);
+const uint_val = msgpack.Payload.uintToPayload(42);
+const float_val = msgpack.Payload.floatToPayload(3.14);
+
+// String and binary
+const str_val = try msgpack.Payload.strToPayload("hello", allocator);
+const bin_val = try msgpack.Payload.binToPayload(&[_]u8{1, 2, 3}, allocator);
+
+// Array
+var arr = try msgpack.Payload.arrPayload(2, allocator);
+try arr.setArrElement(0, msgpack.Payload.intToPayload(1));
+try arr.setArrElement(1, msgpack.Payload.intToPayload(2));
+
+// Extension type
+const ext_val = try msgpack.Payload.extToPayload(5, &[_]u8{0xaa, 0xbb}, allocator);
+```
+
+### Timestamp Usage
+
+```zig
+// Create timestamps
+const ts1 = msgpack.Payload.timestampFromSeconds(1234567890);
+const ts2 = msgpack.Payload.timestampToPayload(1234567890, 123456789);
+
+// Write and read timestamp
+try packer.write(ts2);
+stream.pos = 0;
+const decoded_ts = try packer.read(allocator);
+defer decoded_ts.free(allocator);
+
+std.debug.print("Timestamp: {}s + {}ns\n", 
+    .{ decoded_ts.timestamp.seconds, decoded_ts.timestamp.nanoseconds });
+std.debug.print("As float: {d}\n", .{ decoded_ts.timestamp.toFloat() });
+```
+
+### Error Handling
+
+```zig
+// Type conversion with error handling
+const int_payload = msgpack.Payload.intToPayload(-42);
+const uint_result = int_payload.getUint() catch |err| switch (err) {
+    msgpack.MsGPackError.INVALID_TYPE => {
+        std.debug.print("Cannot convert negative to unsigned\n");
+        return;
+    },
+    else => return err,
+};
 ```
 
 ## API Overview
 
--   **`msgpack.Pack`**: The main struct for packing and unpacking MessagePack data. It is initialized with read and write contexts.
--   **`msgpack.Payload`**: A union that represents any MessagePack type. It provides methods for creating and interacting with different data types (e.g., `mapPayload`, `strToPayload`, `mapGet`).
+- **`msgpack.Pack`**: The main struct for packing and unpacking MessagePack data. It is initialized with read and write contexts.
+- **`msgpack.Payload`**: A union that represents any MessagePack type. It provides methods for creating and interacting with different data types (e.g., `mapPayload`, `strToPayload`, `mapGet`).
 
 ## Testing
 
@@ -121,8 +166,8 @@ Contributions are welcome! Please feel free to open an issue or submit a pull re
 
 ## Related Projects
 
--   [getty-msgpack](https://git.mzte.de/LordMZTE/getty-msgpack)
--   [znvim](https://github.com/jinzhongjia/znvim)
+- [getty-msgpack](https://git.mzte.de/LordMZTE/getty-msgpack)
+- [znvim](https://github.com/jinzhongjia/znvim)
 
 ## License
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,0 +1,175 @@
+# zig-msgpack
+
+[![CI](https://github.com/zigcc/zig-msgpack/actions/workflows/ci.yml/badge.svg)](https://github.com/zigcc/zig-msgpack/actions/workflows/ci.yml)
+
+Zig 编程语言的 MessagePack 实现。此库提供了一种简单高效的方式来使用 MessagePack 格式序列化和反序列化数据。
+
+相关介绍文章: [Zig Msgpack](https://blog.nvimer.org/2025/05/03/zig-msgpack/)
+
+## 特性
+
+- **完整的 MessagePack 支持**: 实现了所有 MessagePack 类型，包括时间戳扩展类型。
+- **时间戳支持**: 完整实现 MessagePack 时间戳扩展类型 (-1)，支持所有三种格式（32位、64位和96位）。
+- **高效**: 设计追求高性能，内存开销最小。
+- **类型安全**: 利用 Zig 的类型系统确保序列化和反序列化期间的安全性。
+- **简单的 API**: 提供直观易用的编码和解码 API。
+
+## 安装
+
+> 对于 Zig 0.13 及更早版本，请使用本库的 `0.0.6` 版本。
+
+对于 Zig `0.14.0` 和 `nightly` 版本，请按以下步骤操作：
+
+1. **添加为依赖项**:
+   将库添加到您的 `build.zig.zon` 文件中。您可以获取特定的提交或分支。
+
+   ```sh
+   zig fetch --save https://github.com/zigcc/zig-msgpack/archive/{COMMIT_OR_BRANCH}.tar.gz
+   ```
+
+2. **配置您的 `build.zig`**:
+   将 `zig-msgpack` 模块添加到您的可执行文件中。
+
+   ```zig
+   const std = @import("std");
+
+   pub fn build(b: *std.Build) void {
+       const target = b.standardTargetOptions(.{});
+       const optimize = b.standardOptimizeOption(.{});
+
+       const exe = b.addExecutable(.{
+           .name = "my-app",
+           .root_source_file = .{ .path = "src/main.zig" },
+           .target = target,
+           .optimize = optimize,
+       });
+
+       const msgpack_dep = b.dependency("zig_msgpack", .{
+           .target = target,
+           .optimize = optimize,
+       });
+
+       exe.root_module.addImport("msgpack", msgpack_dep.module("msgpack"));
+
+       b.installArtifact(exe);
+   }
+   ```
+
+## 使用方法
+
+### 基础用法
+
+```zig
+const std = @import("std");
+const msgpack = @import("msgpack");
+
+pub fn main() !void {
+    const allocator = std.heap.page_allocator;
+    var buffer: [1024]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&buffer);
+
+    var packer = msgpack.Pack(
+        *std.io.FixedBufferStream([]u8), *std.io.FixedBufferStream([]u8),
+        std.io.FixedBufferStream([]u8).WriteError, std.io.FixedBufferStream([]u8).ReadError,
+        std.io.FixedBufferStream([]u8).write, std.io.FixedBufferStream([]u8).read,
+    ).init(&stream, &stream);
+
+    // 创建和编码数据
+    var map = msgpack.Payload.mapPayload(allocator);
+    defer map.free(allocator);
+    try map.mapPut("姓名", try msgpack.Payload.strToPayload("小明", allocator));
+    try map.mapPut("年龄", msgpack.Payload.uintToPayload(25));
+    try packer.write(map);
+
+    // 解码
+    stream.pos = 0;
+    const decoded = try packer.read(allocator);
+    defer decoded.free(allocator);
+    
+    const name = (try decoded.mapGet("姓名")).?.str.value();
+    const age = (try decoded.mapGet("年龄")).?.uint;
+    std.debug.print("姓名: {s}, 年龄: {d}\n", .{ name, age });
+}
+```
+
+### 数据类型
+
+```zig
+// 基础类型
+const nil_val = msgpack.Payload.nilToPayload();
+const bool_val = msgpack.Payload.boolToPayload(true);
+const int_val = msgpack.Payload.intToPayload(-42);
+const uint_val = msgpack.Payload.uintToPayload(42);
+const float_val = msgpack.Payload.floatToPayload(3.14);
+
+// 字符串和二进制数据
+const str_val = try msgpack.Payload.strToPayload("你好", allocator);
+const bin_val = try msgpack.Payload.binToPayload(&[_]u8{1, 2, 3}, allocator);
+
+// 数组
+var arr = try msgpack.Payload.arrPayload(2, allocator);
+try arr.setArrElement(0, msgpack.Payload.intToPayload(1));
+try arr.setArrElement(1, msgpack.Payload.intToPayload(2));
+
+// 扩展类型
+const ext_val = try msgpack.Payload.extToPayload(5, &[_]u8{0xaa, 0xbb}, allocator);
+```
+
+### 时间戳用法
+
+```zig
+// 创建时间戳
+const ts1 = msgpack.Payload.timestampFromSeconds(1234567890);
+const ts2 = msgpack.Payload.timestampToPayload(1234567890, 123456789);
+
+// 写入和读取时间戳
+try packer.write(ts2);
+stream.pos = 0;
+const decoded_ts = try packer.read(allocator);
+defer decoded_ts.free(allocator);
+
+std.debug.print("时间戳: {}秒 + {}纳秒\n", 
+    .{ decoded_ts.timestamp.seconds, decoded_ts.timestamp.nanoseconds });
+std.debug.print("浮点数形式: {d}\n", .{ decoded_ts.timestamp.toFloat() });
+```
+
+### 错误处理
+
+```zig
+// 类型转换与错误处理
+const int_payload = msgpack.Payload.intToPayload(-42);
+const uint_result = int_payload.getUint() catch |err| switch (err) {
+    msgpack.MsGPackError.INVALID_TYPE => {
+        std.debug.print("无法将负数转换为无符号整数\n");
+        return;
+    },
+    else => return err,
+};
+```
+
+## API 概览
+
+- **`msgpack.Pack`**: 用于打包和解包 MessagePack 数据的主要结构体。使用读写上下文进行初始化。
+- **`msgpack.Payload`**: 表示任何 MessagePack 类型的联合体。提供创建和与不同数据类型交互的方法（例如，`mapPayload`、`strToPayload`、`mapGet`）。
+
+## 测试
+
+要运行此库的单元测试，请使用以下命令：
+
+```sh
+zig build test
+```
+
+## 贡献
+
+欢迎贡献！请随时提出问题或提交拉取请求。
+
+## 相关项目
+
+- [getty-msgpack](https://git.mzte.de/LordMZTE/getty-msgpack)
+- [znvim](https://github.com/jinzhongjia/znvim)
+
+## 许可证
+
+此项目在 MIT 许可证下许可。详情请参阅 [LICENSE](LICENSE) 文件。
+

--- a/src/msgpack.zig
+++ b/src/msgpack.zig
@@ -64,6 +64,38 @@ pub fn wrapEXT(t: i8, data: []u8) EXT {
     };
 }
 
+/// the Timestamp Type
+/// Represents an instantaneous point on the time-line in the world
+/// that is independent from time zones or calendars.
+/// Maximum precision is nanoseconds.
+pub const Timestamp = struct {
+    /// seconds since 1970-01-01 00:00:00 UTC
+    seconds: i64,
+    /// nanoseconds (0-999999999)
+    nanoseconds: u32,
+
+    /// Create a new timestamp
+    pub fn new(seconds: i64, nanoseconds: u32) Timestamp {
+        return Timestamp{
+            .seconds = seconds,
+            .nanoseconds = nanoseconds,
+        };
+    }
+
+    /// Create timestamp from seconds only (nanoseconds = 0)
+    pub fn fromSeconds(seconds: i64) Timestamp {
+        return Timestamp{
+            .seconds = seconds,
+            .nanoseconds = 0,
+        };
+    }
+
+    /// Get total seconds as f64 (including fractional nanoseconds)
+    pub fn toFloat(self: Timestamp) f64 {
+        return @as(f64, @floatFromInt(self.seconds)) + @as(f64, @floatFromInt(self.nanoseconds)) / 1_000_000_000.0;
+    }
+};
+
 /// the map of payload
 pub const Map = std.StringHashMap(Payload);
 
@@ -87,6 +119,7 @@ pub const Payload = union(enum) {
     arr: []Payload,
     map: Map,
     ext: EXT,
+    timestamp: Timestamp,
 
     /// get array element
     pub fn getArrElement(self: Payload, index: usize) !Payload {
@@ -219,6 +252,20 @@ pub const Payload = union(enum) {
         @memcpy(new_data, data);
         return Payload{
             .ext = wrapEXT(t, new_data),
+        };
+    }
+
+    /// get a timestamp payload
+    pub fn timestampToPayload(seconds: i64, nanoseconds: u32) Payload {
+        return Payload{
+            .timestamp = Timestamp.new(seconds, nanoseconds),
+        };
+    }
+
+    /// get a timestamp payload from seconds only
+    pub fn timestampFromSeconds(seconds: i64) Payload {
+        return Payload{
+            .timestamp = Timestamp.fromSeconds(seconds),
         };
     }
 
@@ -847,6 +894,43 @@ pub fn Pack(
             }
         }
 
+        /// write timestamp
+        fn writeTimestamp(self: Self, timestamp: Timestamp) !void {
+            // According to MessagePack spec, timestamp uses extension type -1
+            const TIMESTAMP_TYPE: i8 = -1;
+
+            // timestamp 32 format: seconds fit in 32-bit unsigned int and nanoseconds is 0
+            if (timestamp.nanoseconds == 0 and timestamp.seconds >= 0 and timestamp.seconds <= 0xffffffff) {
+                var data: [4]u8 = undefined;
+                std.mem.writeInt(u32, &data, @intCast(timestamp.seconds), big_endian);
+                const ext = EXT{ .type = TIMESTAMP_TYPE, .data = &data };
+                try self.writeExt(ext);
+                return;
+            }
+
+            // timestamp 64 format: seconds fit in 34-bit and nanoseconds <= 999999999
+            if (timestamp.seconds >= 0 and (timestamp.seconds >> 34) == 0 and timestamp.nanoseconds <= 999999999) {
+                const data64: u64 = (@as(u64, timestamp.nanoseconds) << 34) | @as(u64, @intCast(timestamp.seconds));
+                var data: [8]u8 = undefined;
+                std.mem.writeInt(u64, &data, data64, big_endian);
+                const ext = EXT{ .type = TIMESTAMP_TYPE, .data = &data };
+                try self.writeExt(ext);
+                return;
+            }
+
+            // timestamp 96 format: full range with signed 64-bit seconds and 32-bit nanoseconds
+            if (timestamp.nanoseconds <= 999999999) {
+                var data: [12]u8 = undefined;
+                std.mem.writeInt(u32, data[0..4], timestamp.nanoseconds, big_endian);
+                std.mem.writeInt(i64, data[4..12], timestamp.seconds, big_endian);
+                const ext = EXT{ .type = TIMESTAMP_TYPE, .data = &data };
+                try self.writeExt(ext);
+                return;
+            }
+
+            return MsGPackError.INVALID_TYPE;
+        }
+
         /// write payload
         pub fn write(self: Self, payload: Payload) !void {
             switch (payload) {
@@ -911,6 +995,9 @@ pub fn Pack(
                 },
                 .ext => |ext| {
                     try self.writeExt(ext);
+                },
+                .timestamp => |timestamp| {
+                    try self.writeTimestamp(timestamp);
                 },
             }
         }
@@ -1284,6 +1371,153 @@ pub fn Pack(
             };
         }
 
+        /// read ext value or timestamp if it's timestamp type (-1)
+        fn readExtValueOrTimestamp(self: Self, marker: Markers, allocator: Allocator) !Payload {
+            const TIMESTAMP_TYPE: i8 = -1;
+
+            // First, check if this could be a timestamp format
+            if (marker == .FIXEXT4 or marker == .FIXEXT8 or marker == .EXT8) {
+                // Read and check length for EXT8
+                var actual_len: usize = 0;
+                if (marker == .EXT8) {
+                    actual_len = try self.readV8Value();
+                    if (actual_len != 12) {
+                        // Not timestamp 96, read as regular EXT
+                        const ext_type = try self.readI8Value();
+                        const ext_data = try allocator.alloc(u8, actual_len);
+                        _ = try self.readFrom(ext_data);
+                        return Payload{ .ext = EXT{ .type = ext_type, .data = ext_data } };
+                    }
+                } else if (marker == .FIXEXT4) {
+                    actual_len = 4;
+                } else if (marker == .FIXEXT8) {
+                    actual_len = 8;
+                }
+
+                // Read the type
+                const ext_type = try self.readI8Value();
+
+                if (ext_type == TIMESTAMP_TYPE) {
+                    // This is a timestamp
+                    if (marker == .FIXEXT4) {
+                        // timestamp 32
+                        const seconds = try self.readU32Value();
+                        return Payload{ .timestamp = Timestamp.new(@intCast(seconds), 0) };
+                    } else if (marker == .FIXEXT8) {
+                        // timestamp 64
+                        const data64 = try self.readU64Value();
+                        const nanoseconds: u32 = @intCast(data64 >> 34);
+                        const seconds: i64 = @intCast(data64 & 0x3ffffffff);
+                        return Payload{ .timestamp = Timestamp.new(seconds, nanoseconds) };
+                    } else if (marker == .EXT8) {
+                        // timestamp 96
+                        const nanoseconds = try self.readU32Value();
+                        const seconds = try self.readI64Value();
+                        return Payload{ .timestamp = Timestamp.new(seconds, nanoseconds) };
+                    }
+                } else {
+                    // Not a timestamp, read as regular EXT
+                    const ext_data = try allocator.alloc(u8, actual_len);
+                    _ = try self.readFrom(ext_data);
+                    return Payload{ .ext = EXT{ .type = ext_type, .data = ext_data } };
+                }
+            }
+
+            // Regular EXT processing
+            const val = try self.readExtValue(marker, allocator);
+            return Payload{ .ext = val };
+        }
+
+        /// try to read timestamp from ext data, return error if not timestamp
+        fn tryReadTimestamp(self: Self, marker: Markers, _: Allocator) !Timestamp {
+            const TIMESTAMP_TYPE: i8 = -1;
+
+            switch (marker) {
+                .FIXEXT4 => {
+                    // timestamp 32 format
+                    const ext_type = try self.readI8Value();
+                    if (ext_type != TIMESTAMP_TYPE) {
+                        return MsGPackError.INVALID_TYPE;
+                    }
+                    const seconds = try self.readU32Value();
+                    return Timestamp.new(@intCast(seconds), 0);
+                },
+                .FIXEXT8 => {
+                    // timestamp 64 format
+                    const ext_type = try self.readI8Value();
+                    if (ext_type != TIMESTAMP_TYPE) {
+                        return MsGPackError.INVALID_TYPE;
+                    }
+                    const data64 = try self.readU64Value();
+                    const nanoseconds: u32 = @intCast(data64 >> 34);
+                    const seconds: i64 = @intCast(data64 & 0x3ffffffff);
+                    return Timestamp.new(seconds, nanoseconds);
+                },
+                .EXT8 => {
+                    // timestamp 96 format (length should be 12)
+                    const len = try self.readV8Value();
+                    if (len != 12) {
+                        return MsGPackError.INVALID_TYPE;
+                    }
+                    const ext_type = try self.readI8Value();
+                    if (ext_type != TIMESTAMP_TYPE) {
+                        return MsGPackError.INVALID_TYPE;
+                    }
+                    const nanoseconds = try self.readU32Value();
+                    const seconds = try self.readI64Value();
+                    return Timestamp.new(seconds, nanoseconds);
+                },
+                else => {
+                    return MsGPackError.INVALID_TYPE;
+                },
+            }
+        }
+
+        /// read timestamp from ext data
+        fn readTimestamp(self: Self, marker: Markers, _: Allocator) !Timestamp {
+            const TIMESTAMP_TYPE: i8 = -1;
+
+            switch (marker) {
+                .FIXEXT4 => {
+                    // timestamp 32 format
+                    const ext_type = try self.readI8Value();
+                    if (ext_type != TIMESTAMP_TYPE) {
+                        return MsGPackError.INVALID_TYPE;
+                    }
+                    const seconds = try self.readU32Value();
+                    return Timestamp.new(@intCast(seconds), 0);
+                },
+                .FIXEXT8 => {
+                    // timestamp 64 format
+                    const ext_type = try self.readI8Value();
+                    if (ext_type != TIMESTAMP_TYPE) {
+                        return MsGPackError.INVALID_TYPE;
+                    }
+                    const data64 = try self.readU64Value();
+                    const nanoseconds: u32 = @intCast(data64 >> 34);
+                    const seconds: i64 = @intCast(data64 & 0x3ffffffff);
+                    return Timestamp.new(seconds, nanoseconds);
+                },
+                .EXT8 => {
+                    // timestamp 96 format (length should be 12)
+                    const len = try self.readV8Value();
+                    if (len != 12) {
+                        return MsGPackError.INVALID_TYPE;
+                    }
+                    const ext_type = try self.readI8Value();
+                    if (ext_type != TIMESTAMP_TYPE) {
+                        return MsGPackError.INVALID_TYPE;
+                    }
+                    const nanoseconds = try self.readU32Value();
+                    const seconds = try self.readI64Value();
+                    return Timestamp.new(seconds, nanoseconds);
+                },
+                else => {
+                    return MsGPackError.INVALID_TYPE;
+                },
+            }
+        }
+
         fn readExtValue(self: Self, marker: Markers, allocator: Allocator) !EXT {
             switch (marker) {
                 .FIXEXT1 => {
@@ -1446,10 +1680,8 @@ pub fn Pack(
                 .EXT16,
                 .EXT32,
                 => {
-                    const val = try self.readExtValue(marker, allocator);
-                    res = Payload{
-                        .ext = val,
-                    };
+                    const ext_result = try self.readExtValueOrTimestamp(marker, allocator);
+                    res = ext_result;
                 },
             }
             return res;

--- a/src/test.zig
+++ b/src/test.zig
@@ -869,7 +869,7 @@ test "array32 write and read" {
     const test_size = 0x10000;
     var test_payload = try Payload.arrPayload(test_size, allocator);
     defer test_payload.free(allocator);
-    
+
     for (0..test_size) |i| {
         try test_payload.setArrElement(i, Payload.uintToPayload(i % 256));
     }
@@ -959,7 +959,7 @@ test "str16 and str32 write and read" {
     const str32_data = try allocator.alloc(u8, 65536);
     defer allocator.free(str32_data);
     @memset(str32_data, 'A');
-    
+
     const str32_payload = try Payload.strToPayload(str32_data, allocator);
     defer str32_payload.free(allocator);
     try p.write(str32_payload);
@@ -1163,7 +1163,7 @@ test "actual map32 format" {
     // Note: This test would be very memory intensive with 65536+ entries
     // Instead, we test the boundary where map32 format would be used
     // by verifying the implementation handles large maps correctly
-    
+
     var arr: [0xfffff]u8 = std.mem.zeroes([0xfffff]u8);
     var write_buffer = std.io.fixedBufferStream(&arr);
     var read_buffer = std.io.fixedBufferStream(&arr);
@@ -1194,17 +1194,17 @@ test "actual map32 format" {
     defer val.free(allocator);
 
     try expect(val.map.count() == 1000);
-    
+
     // Verify some entries exist and have correct values
     const first_key = try std.fmt.allocPrint(allocator, "key{d:0>10}", .{0});
     defer allocator.free(first_key);
     const last_key = try std.fmt.allocPrint(allocator, "key{d:0>10}", .{999});
     defer allocator.free(last_key);
-    
+
     const first_value = try val.mapGet(first_key);
     try expect(first_value != null);
     try expect(try first_value.?.getInt() == 0);
-    
+
     const last_value = try val.mapGet(last_key);
     try expect(last_value != null);
     try expect(try last_value.?.getInt() == 999);
@@ -1220,7 +1220,7 @@ test "edge cases and error conditions" {
     // Test array index out of bounds
     var test_arr = try Payload.arrPayload(3, allocator);
     defer test_arr.free(allocator);
-    
+
     // This should work
     try test_arr.setArrElement(0, Payload.nilToPayload());
     try test_arr.setArrElement(1, Payload.boolToPayload(true));
@@ -1229,7 +1229,7 @@ test "edge cases and error conditions" {
     try p.write(test_arr);
     const val = try p.read(allocator);
     defer val.free(allocator);
-    
+
     try expect((try val.getArrLen()) == 3);
     try expect((try val.getArrElement(0)) == .nil);
     try expect((try val.getArrElement(1)).bool == true);
@@ -1250,7 +1250,7 @@ test "ext negative type ids" {
     try p.write(.{ .ext = msgpack.wrapEXT(negative_type, &test_data) });
     const val = try p.read(allocator);
     defer val.free(allocator);
-    
+
     try expect(val.ext.type == negative_type);
     try expect(u8eql(&test_data, val.ext.data));
 
@@ -1264,7 +1264,7 @@ test "ext negative type ids" {
     try p.write(.{ .ext = msgpack.wrapEXT(min_type, &test_data) });
     const val2 = try p.read(allocator);
     defer val2.free(allocator);
-    
+
     try expect(val2.ext.type == min_type);
     try expect(u8eql(&test_data, val2.ext.data));
 }
@@ -1287,7 +1287,7 @@ test "format markers verification" {
     // Test bool markers
     try p.write(Payload.boolToPayload(true));
     try expect(arr[0] == 0xc3); // TRUE marker
-    
+
     try p.write(Payload.boolToPayload(false));
     try expect(arr[1] == 0xc2); // FALSE marker
 
@@ -1334,7 +1334,7 @@ test "format markers verification" {
     // Test map16 marker (16+ entries uses map16)
     var test_map = Payload.mapPayload(allocator);
     defer test_map.free(allocator);
-    
+
     var test_keys = std.ArrayList([]u8).init(allocator);
     defer {
         for (test_keys.items) |key| {
@@ -1342,7 +1342,7 @@ test "format markers verification" {
         }
         test_keys.deinit();
     }
-    
+
     for (0..16) |i| {
         const key = try std.fmt.allocPrint(allocator, "k{d}", .{i});
         try test_keys.append(key);
@@ -1361,7 +1361,7 @@ test "positive fixint boundary" {
 
     // Test boundary values for positive fixint (0-127)
     const boundary_values = [_]u64{ 0, 1, 126, 127, 128 };
-    
+
     for (boundary_values) |val| {
         try p.write(.{ .uint = val });
     }
@@ -1386,11 +1386,11 @@ test "fixstr boundary" {
 
     // Test different fixstr lengths
     const test_strings = [_][]const u8{
-        "",           // 0 bytes
-        "a",          // 1 byte
-        "hello",      // 5 bytes
-        "a" ** 31,    // 31 bytes (max fixstr)
-        "b" ** 32,    // 32 bytes (should use str8)
+        "", // 0 bytes
+        "a", // 1 byte
+        "hello", // 5 bytes
+        "a" ** 31, // 31 bytes (max fixstr)
+        "b" ** 32, // 32 bytes (should use str8)
     };
 
     for (test_strings) |test_str| {
@@ -1423,11 +1423,11 @@ test "fixarray boundary" {
     for (test_sizes) |size| {
         var test_payload = try Payload.arrPayload(size, allocator);
         defer test_payload.free(allocator);
-        
+
         for (0..size) |i| {
             try test_payload.setArrElement(i, Payload.uintToPayload(i));
         }
-        
+
         try p.write(test_payload);
     }
 
@@ -1439,7 +1439,7 @@ test "fixarray boundary" {
         const result = try p.read(allocator);
         defer result.free(allocator);
         try expect((try result.getArrLen()) == expected_size);
-        
+
         for (0..expected_size) |i| {
             const element = try result.getArrElement(i);
             try expect(element.uint == i);
@@ -1460,17 +1460,17 @@ test "fixmap boundary" {
     for (test_sizes) |size| {
         var test_map = Payload.mapPayload(allocator);
         defer test_map.free(allocator);
-        
+
         for (0..size) |i| {
             const key = try std.fmt.allocPrint(allocator, "k{d}", .{i});
             defer allocator.free(key);
             try test_map.mapPut(key, Payload.uintToPayload(i));
         }
-        
+
         try p.write(test_map);
     }
 
-    // Reset read buffer  
+    // Reset read buffer
     read_buffer = std.io.fixedBufferStream(&arr);
     p = pack.init(&write_buffer, &read_buffer);
 
@@ -1478,7 +1478,7 @@ test "fixmap boundary" {
         const result = try p.read(allocator);
         defer result.free(allocator);
         try expect(result.map.count() == expected_size);
-        
+
         for (0..expected_size) |i| {
             const key = try std.fmt.allocPrint(allocator, "k{d}", .{i});
             defer allocator.free(key);

--- a/src/test.zig
+++ b/src/test.zig
@@ -106,7 +106,9 @@ test "str write and read" {
     );
 
     const test_str = "Hello, world!";
-    try p.write(.{ .str = msgpack.wrapStr(test_str) });
+    const str_payload = try Payload.strToPayload(test_str, allocator);
+    defer str_payload.free(allocator);
+    try p.write(str_payload);
     const val = try p.read(allocator);
     defer val.free(allocator);
     try expect(u8eql(test_str, val.str.value()));
@@ -255,4 +257,601 @@ test "ext write and read" {
     defer val.free(allocator);
     try expect(u8eql(&test_data, val.ext.data));
     try expect(test_type == val.ext.type);
+}
+
+// Test error handling for Payload methods
+test "payload error handling" {
+    // Test NotArr error
+    const not_arr_payload = Payload.nilToPayload();
+    const arr_len_result = not_arr_payload.getArrLen();
+    try expect(arr_len_result == Payload.Errors.NotArr);
+
+    const arr_element_result = not_arr_payload.getArrElement(0);
+    try expect(arr_element_result == Payload.Errors.NotArr);
+
+    var mut_not_arr = Payload.nilToPayload();
+    const set_arr_result = mut_not_arr.setArrElement(0, Payload.nilToPayload());
+    try expect(set_arr_result == Payload.Errors.NotArr);
+
+    // Test NotMap error
+    const not_map_payload = Payload.nilToPayload();
+    const map_get_result = not_map_payload.mapGet("test");
+    try expect(map_get_result == Payload.Errors.NotMap);
+
+    var mut_not_map = Payload.nilToPayload();
+    const map_put_result = mut_not_map.mapPut("test", Payload.nilToPayload());
+    try expect(map_put_result == Payload.Errors.NotMap);
+}
+
+// Test boundary values for integers
+test "integer boundary values" {
+    var arr: [0xffff_f]u8 = std.mem.zeroes([0xffff_f]u8);
+    var write_buffer = std.io.fixedBufferStream(&arr);
+    var read_buffer = std.io.fixedBufferStream(&arr);
+    var p = pack.init(&write_buffer, &read_buffer);
+
+    // Test maximum positive values
+    const max_u8: u64 = 0xff;
+    try p.write(.{ .uint = max_u8 });
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(val.uint == max_u8);
+    }
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    const max_u16: u64 = 0xffff;
+    try p.write(.{ .uint = max_u16 });
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(val.uint == max_u16);
+    }
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    const max_u32: u64 = 0xffffffff;
+    try p.write(.{ .uint = max_u32 });
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(val.uint == max_u32);
+    }
+
+    // Test minimum negative values
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    const min_i8: i64 = -128;
+    try p.write(.{ .int = min_i8 });
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(val.int == min_i8);
+    }
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    const min_i16: i64 = -32768;
+    try p.write(.{ .int = min_i16 });
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(val.int == min_i16);
+    }
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    const min_i32: i64 = -2147483648;
+    try p.write(.{ .int = min_i32 });
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(val.int == min_i32);
+    }
+}
+
+// Test different string sizes
+test "string size boundaries" {
+    var arr: [0xffff_f]u8 = std.mem.zeroes([0xffff_f]u8);
+    var write_buffer = std.io.fixedBufferStream(&arr);
+    var read_buffer = std.io.fixedBufferStream(&arr);
+    var p = pack.init(&write_buffer, &read_buffer);
+
+    // Test fixstr (31 bytes)
+    const fixstr_31_data = "a" ** 31;
+    const fixstr_31_payload = try Payload.strToPayload(fixstr_31_data, allocator);
+    defer fixstr_31_payload.free(allocator);
+    try p.write(fixstr_31_payload);
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(u8eql(fixstr_31_data, val.str.value()));
+    }
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    // Test str8 (255 bytes)
+    const str8_255_data = "b" ** 255;
+    const str8_255_payload = try Payload.strToPayload(str8_255_data, allocator);
+    defer str8_255_payload.free(allocator);
+    try p.write(str8_255_payload);
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(u8eql(str8_255_data, val.str.value()));
+    }
+}
+
+// Test empty containers
+test "empty containers" {
+    var arr: [0xffff_f]u8 = std.mem.zeroes([0xffff_f]u8);
+    var write_buffer = std.io.fixedBufferStream(&arr);
+    var read_buffer = std.io.fixedBufferStream(&arr);
+    var p = pack.init(&write_buffer, &read_buffer);
+
+    // Test empty array
+    const empty_arr = try Payload.arrPayload(0, allocator);
+    defer empty_arr.free(allocator);
+    try p.write(empty_arr);
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect((try val.getArrLen()) == 0);
+    }
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    // Test empty map
+    const empty_map = Payload.mapPayload(allocator);
+    defer empty_map.free(allocator);
+    try p.write(empty_map);
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(val.map.count() == 0);
+    }
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    // Test empty string
+    const empty_str_payload = try Payload.strToPayload("", allocator);
+    defer empty_str_payload.free(allocator);
+    try p.write(empty_str_payload);
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(u8eql("", val.str.value()));
+    }
+}
+
+// Test different EXT sizes
+test "ext different sizes" {
+    var arr: [0xffff_f]u8 = std.mem.zeroes([0xffff_f]u8);
+    var write_buffer = std.io.fixedBufferStream(&arr);
+    var read_buffer = std.io.fixedBufferStream(&arr);
+    var p = pack.init(&write_buffer, &read_buffer);
+
+    // Test fixext1
+    var ext1_data = [1]u8{0x42};
+    try p.write(.{ .ext = msgpack.wrapEXT(1, &ext1_data) });
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(val.ext.type == 1);
+        try expect(u8eql(&ext1_data, val.ext.data));
+    }
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    // Test fixext2
+    var ext2_data = [2]u8{ 0x42, 0x43 };
+    try p.write(.{ .ext = msgpack.wrapEXT(2, &ext2_data) });
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(val.ext.type == 2);
+        try expect(u8eql(&ext2_data, val.ext.data));
+    }
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    // Test fixext4
+    var ext4_data = [4]u8{ 0x42, 0x43, 0x44, 0x45 };
+    try p.write(.{ .ext = msgpack.wrapEXT(3, &ext4_data) });
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(val.ext.type == 3);
+        try expect(u8eql(&ext4_data, val.ext.data));
+    }
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    // Test fixext8
+    var ext8_data = [8]u8{ 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49 };
+    try p.write(.{ .ext = msgpack.wrapEXT(4, &ext8_data) });
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(val.ext.type == 4);
+        try expect(u8eql(&ext8_data, val.ext.data));
+    }
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    // Test fixext16
+    var ext16_data = [16]u8{ 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51 };
+    try p.write(.{ .ext = msgpack.wrapEXT(5, &ext16_data) });
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(val.ext.type == 5);
+        try expect(u8eql(&ext16_data, val.ext.data));
+    }
+}
+
+// Test float precision
+test "float precision" {
+    var arr: [0xffff_f]u8 = std.mem.zeroes([0xffff_f]u8);
+    var write_buffer = std.io.fixedBufferStream(&arr);
+    var read_buffer = std.io.fixedBufferStream(&arr);
+    var p = pack.init(&write_buffer, &read_buffer);
+
+    // Test f32 range value
+    const f32_val: f64 = 3.14159;
+    try p.write(.{ .float = f32_val });
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        // Check if value is approximately equal (due to f32 precision loss)
+        try expect(@abs(val.float - f32_val) < 0.0001);
+    }
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    // Test f64 value that exceeds f32 range
+    const f64_val: f64 = 1.7976931348623157e+308; // Near f64 max
+    try p.write(.{ .float = f64_val });
+    {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(val.float == f64_val);
+    }
+}
+
+// Test payload utility methods
+test "payload utility methods" {
+    // Test all ToPayload methods
+    try expect(Payload.nilToPayload() == .nil);
+    try expect(Payload.boolToPayload(true).bool == true);
+    try expect(Payload.intToPayload(-42).int == -42);
+    try expect(Payload.uintToPayload(42).uint == 42);
+    try expect(Payload.floatToPayload(3.14).float == 3.14);
+
+    const str_payload = try Payload.strToPayload("test", allocator);
+    defer str_payload.free(allocator);
+    try expect(u8eql("test", str_payload.str.value()));
+
+    const bin_payload = try Payload.binToPayload("binary", allocator);
+    defer bin_payload.free(allocator);
+    try expect(u8eql("binary", bin_payload.bin.value()));
+
+    const ext_payload = try Payload.extToPayload(1, "extdata", allocator);
+    defer ext_payload.free(allocator);
+    try expect(ext_payload.ext.type == 1);
+    try expect(u8eql("extdata", ext_payload.ext.data));
+
+    const arr_payload = try Payload.arrPayload(3, allocator);
+    defer arr_payload.free(allocator);
+    try expect((try arr_payload.getArrLen()) == 3);
+
+    const map_payload = Payload.mapPayload(allocator);
+    defer map_payload.free(allocator);
+    try expect(map_payload.map.count() == 0);
+}
+
+// Test negative fixint range
+test "negative fixint range" {
+    var arr: [0xffff_f]u8 = std.mem.zeroes([0xffff_f]u8);
+    var write_buffer = std.io.fixedBufferStream(&arr);
+    var read_buffer = std.io.fixedBufferStream(&arr);
+    var p = pack.init(&write_buffer, &read_buffer);
+
+    // Test all values in negative fixint range (-32 to -1)
+    for (1..33) |i| {
+        const val: i64 = -@as(i64, @intCast(i));
+        try p.write(.{ .int = val });
+    }
+
+    // Reset read buffer
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    for (1..33) |i| {
+        const expected: i64 = -@as(i64, @intCast(i));
+        const result = try p.read(allocator);
+        defer result.free(allocator);
+        try expect(result.int == expected);
+    }
+}
+
+// Test map with non-existent key
+test "map operations" {
+    var test_map = Payload.mapPayload(allocator);
+    defer test_map.free(allocator);
+
+    // Test getting non-existent key
+    const result = try test_map.mapGet("nonexistent");
+    try expect(result == null);
+
+    // Test putting and getting
+    try test_map.mapPut("key1", Payload.intToPayload(42));
+    const value = try test_map.mapGet("key1");
+    try expect(value != null);
+    try expect(value.?.int == 42);
+
+    // Test overwriting existing key
+    try test_map.mapPut("key1", Payload.intToPayload(100));
+    const new_value = try test_map.mapGet("key1");
+    try expect(new_value != null);
+    try expect(new_value.?.int == 100);
+}
+
+// Test array operations
+test "array operations" {
+    var test_arr = try Payload.arrPayload(3, allocator);
+    defer test_arr.free(allocator);
+
+    // Set all elements
+    for (0..3) |i| {
+        try test_arr.setArrElement(i, Payload.intToPayload(@intCast(i * 10)));
+    }
+
+    // Get all elements
+    for (0..3) |i| {
+        const element = try test_arr.getArrElement(i);
+        try expect(element.int == @as(i64, @intCast(i * 10)));
+    }
+
+    // Test array length
+    try expect((try test_arr.getArrLen()) == 3);
+}
+
+// Test special float values
+test "special float values" {
+    var arr: [0xffff_f]u8 = std.mem.zeroes([0xffff_f]u8);
+    var write_buffer = std.io.fixedBufferStream(&arr);
+    var read_buffer = std.io.fixedBufferStream(&arr);
+    var p = pack.init(&write_buffer, &read_buffer);
+
+    // Test zero
+    try p.write(.{ .float = 0.0 });
+    var val = try p.read(allocator);
+    defer val.free(allocator);
+    try expect(val.float == 0.0);
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    // Test negative zero
+    try p.write(.{ .float = -0.0 });
+    val = try p.read(allocator);
+    defer val.free(allocator);
+    try expect(val.float == -0.0);
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    // Test very small positive number
+    const small_pos: f64 = 1e-100;
+    try p.write(.{ .float = small_pos });
+    val = try p.read(allocator);
+    defer val.free(allocator);
+    try expect(val.float == small_pos);
+
+    // Reset buffers
+    arr = std.mem.zeroes([0xffff_f]u8);
+    write_buffer = std.io.fixedBufferStream(&arr);
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    // Test very small negative number
+    const small_neg: f64 = -1e-100;
+    try p.write(.{ .float = small_neg });
+    val = try p.read(allocator);
+    defer val.free(allocator);
+    try expect(val.float == small_neg);
+}
+
+// Test Unicode strings
+test "unicode strings" {
+    var arr: [0xffff_f]u8 = std.mem.zeroes([0xffff_f]u8);
+    var write_buffer = std.io.fixedBufferStream(&arr);
+    var read_buffer = std.io.fixedBufferStream(&arr);
+    var p = pack.init(&write_buffer, &read_buffer);
+
+    // Test various Unicode strings
+    const unicode_strings = [_][]const u8{
+        "Hello, 世界",
+        "🚀🌟✨",
+        "Привет мир",
+        "مرحبا بالعالم",
+        "こんにちは世界",
+    };
+
+    for (unicode_strings) |unicode_str| {
+        const unicode_payload = try Payload.strToPayload(unicode_str, allocator);
+        defer unicode_payload.free(allocator);
+        try p.write(unicode_payload);
+    }
+
+    // Reset read buffer
+    read_buffer = std.io.fixedBufferStream(&arr);
+    p = pack.init(&write_buffer, &read_buffer);
+
+    for (unicode_strings) |expected| {
+        const val = try p.read(allocator);
+        defer val.free(allocator);
+        try expect(u8eql(expected, val.str.value()));
+    }
+}
+
+// Test nested structures
+test "deeply nested structures" {
+    var arr: [0xffff_f]u8 = std.mem.zeroes([0xffff_f]u8);
+    var write_buffer = std.io.fixedBufferStream(&arr);
+    var read_buffer = std.io.fixedBufferStream(&arr);
+    var p = pack.init(&write_buffer, &read_buffer);
+
+    // Create deeply nested array [[[42]]]
+    var inner_arr = try Payload.arrPayload(1, allocator);
+    try inner_arr.setArrElement(0, Payload.intToPayload(42));
+
+    var middle_arr = try Payload.arrPayload(1, allocator);
+    try middle_arr.setArrElement(0, inner_arr);
+
+    var outer_arr = try Payload.arrPayload(1, allocator);
+    try outer_arr.setArrElement(0, middle_arr);
+
+    defer outer_arr.free(allocator);
+
+    try p.write(outer_arr);
+    const val = try p.read(allocator);
+    defer val.free(allocator);
+
+    // Navigate to deeply nested value
+    const level1 = try val.getArrElement(0);
+    const level2 = try level1.getArrElement(0);
+    const level3 = try level2.getArrElement(0);
+    try expect(try level3.getInt() == 42);
+}
+
+// Test mixed type arrays
+test "mixed type arrays" {
+    var arr: [0xffff_f]u8 = std.mem.zeroes([0xffff_f]u8);
+    var write_buffer = std.io.fixedBufferStream(&arr);
+    var read_buffer = std.io.fixedBufferStream(&arr);
+    var p = pack.init(&write_buffer, &read_buffer);
+
+    var mixed_arr = try Payload.arrPayload(6, allocator);
+    defer mixed_arr.free(allocator);
+
+    try mixed_arr.setArrElement(0, Payload.nilToPayload());
+    try mixed_arr.setArrElement(1, Payload.boolToPayload(true));
+    try mixed_arr.setArrElement(2, Payload.intToPayload(-123));
+    try mixed_arr.setArrElement(3, Payload.uintToPayload(456));
+    try mixed_arr.setArrElement(4, Payload.floatToPayload(78.9));
+    try mixed_arr.setArrElement(5, try Payload.strToPayload("mixed", allocator));
+
+    try p.write(mixed_arr);
+    const val = try p.read(allocator);
+    defer val.free(allocator);
+
+    try expect((try val.getArrElement(0)) == .nil);
+    try expect((try val.getArrElement(1)).bool == true);
+    try expect((try val.getArrElement(2)).int == -123);
+    try expect((try val.getArrElement(3)).uint == 456);
+    // Use approximate comparison for float values due to f32 precision loss
+    try expect(@abs((try val.getArrElement(4)).float - 78.9) < 0.01);
+    try expect(u8eql("mixed", (try val.getArrElement(5)).str.value()));
+}
+
+// Test large maps
+test "large maps" {
+    var arr: [0xffff_f]u8 = std.mem.zeroes([0xffff_f]u8);
+    var write_buffer = std.io.fixedBufferStream(&arr);
+    var read_buffer = std.io.fixedBufferStream(&arr);
+    var p = pack.init(&write_buffer, &read_buffer);
+
+    var large_map = Payload.mapPayload(allocator);
+    defer large_map.free(allocator);
+
+    // Store allocated keys to free them later
+    var keys = std.ArrayList([]u8).init(allocator);
+    defer {
+        for (keys.items) |key| {
+            allocator.free(key);
+        }
+        keys.deinit();
+    }
+
+    // Create a map with 20 entries (more than fixmap limit of 15)
+    for (0..20) |i| {
+        const key = try std.fmt.allocPrint(allocator, "key{d}", .{i});
+        try keys.append(key);
+        try large_map.mapPut(key, Payload.intToPayload(@intCast(i)));
+    }
+
+    try p.write(large_map);
+    const val = try p.read(allocator);
+    defer val.free(allocator);
+
+    try expect(val.map.count() == 20);
+
+    // Verify some entries
+    const value0 = try val.mapGet("key0");
+    try expect(value0 != null);
+    try expect(try value0.?.getInt() == 0);
+
+    const value19 = try val.mapGet("key19");
+    try expect(value19 != null);
+    try expect(try value19.?.getInt() == 19);
 }


### PR DESCRIPTION
- add tests for error handling in Payload methods
- test integer, string, array, map, ext, and float boundaries
- add tests for Unicode strings, nested structures, and mixed arrays
- verify correct handling of empty containers and large maps
- ensure mapPut frees old keys and arrPayload initializes elements
- add getInt and getUint utility methods to Payload
- fix MAP16 and MAP32 encoding to write length after type marker